### PR TITLE
Added /edit API route

### DIFF
--- a/acm_url/routes.py
+++ b/acm_url/routes.py
@@ -92,3 +92,22 @@ def all():
     next_url = url_for('all', page=links.next_num) if links.has_next else None
     prev_url = url_for('all', page=links.prev_num) if links.has_prev else None
     return render_template('links.html', links=links.items,next_url=next_url, prev_url=prev_url)
+
+@app.route('/edit', methods=['POST'])
+def edit():
+    # Grab request data
+    vanity = request.form['vanity']
+    url = request.form['url']
+
+    # Check if vanity exists
+    entry = URL.query.filter(func.lower(URL.vanity) == func.lower(vanity)).first()
+    if entry is None:
+        return f"No vanity found with name {vanity}", 404
+
+    # Update database
+    if not(url.startswith('http://') or url.startswith('https://')):
+        url = 'https://' + url
+    entry.url = url
+    db.session.commit()
+
+    return "Complete", 200


### PR DESCRIPTION
Added the /edit API route.
Users can POST form data to edit a vanity's URL.
Bad form data returns a 400 error: Bad Request
If no vanity exists, return a 404 error: Not Found